### PR TITLE
Android support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0
+
+- Bump Kotlin version
+
 ## 0.1.0
 
 Add a `gamepads` method for retrieving current gamepad info.

--- a/README.md
+++ b/README.md
@@ -2,15 +2,19 @@
 
 A platform library for listening to hardware gamepads (game controllers) from Flutter.
 
-**Currently supports iOS only. Android coming soon!**
-
 ## Features
 
 * `FlutterGamepad.gamepads()` returns info about all currently connected gamepads.
 * `FlutterGamepad.eventStream` reports gamepad events.
 * Fractional button values, such as those reported by the left and right trigger buttons on most gamepads, are supported.
 * Supports iOS 13+, as well as older versions of iOS.
+* Supports Android.
 * Supports multiple simultaneous gamepads. Events are tagged with an ID you can tell gamepads apart by.
+
+## Caveats
+
+* On Android, the B button seems to trigger a "back" action. You'll want to have a `WillPopScope` on your game scaffold to prevent this.
+* On Android, "disconnect" events are never fired. "Connect" events are fired initially when listening to the stream, and thereafter on the first input of any new gamepads. This differs from the iOS behavior, where a "connect" event is sent when the connection is established even if no buttons have been pressed.
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A platform library for listening to hardware gamepads (game controllers) from Fl
 ## Features
 
 * `FlutterGamepad.gamepads()` returns info about all currently connected gamepads.
-* `FlutterGamepad.eventStream` reports gamepad events.
+* `FlutterGamepad.eventStream` reports gamepad events. (See example)
 * Fractional button values, such as those reported by the left and right trigger buttons on most gamepads, are supported.
 * Supports iOS 13+, as well as older versions of iOS.
 * Supports Android.
@@ -14,7 +14,7 @@ A platform library for listening to hardware gamepads (game controllers) from Fl
 ## Caveats
 
 * On Android, the B button seems to trigger a "back" action. You'll want to have a `WillPopScope` on your game scaffold to prevent this.
-* On Android, "disconnect" events are never fired. "Connect" events are fired initially when listening to the stream, and thereafter on the first input of any new gamepads. This differs from the iOS behavior, where a "connect" event is sent when the connection is established even if no buttons have been pressed.
+* On Android, "disconnect" events are never fired. "Connect" events are fired initially when listening to the stream, and thereafter on the first input of any new gamepads. This differs from the iOS behavior, where a "connect" event is sent when the connection is established, even if no buttons have been pressed.
 
 ## Example
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
@@ -41,4 +41,29 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+}
+
+afterEvaluate {
+    def containsEmbeddingDependencies = false
+    for (def configuration : configurations.all) {
+        for (def dependency : configuration.dependencies) {
+            if (dependency.group == 'io.flutter' &&
+                    dependency.name.startsWith('flutter_embedding') &&
+                    dependency.isTransitive())
+            {
+                containsEmbeddingDependencies = true
+                break
+            }
+        }
+    }
+    if (!containsEmbeddingDependencies) {
+        android {
+            dependencies {
+                def lifecycle_version = "1.1.1"
+                compileOnly "android.arch.lifecycle:runtime:$lifecycle_version"
+                compileOnly "android.arch.lifecycle:common:$lifecycle_version"
+                compileOnly "android.arch.lifecycle:common-java8:$lifecycle_version"
+            }
+        }
+    }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ group 'com.example.flutter_gamepad'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.2.71'
+    ext.kotlin_version = '1.3.50'
     repositories {
         google()
         jcenter()

--- a/android/src/main/kotlin/com/example/flutter_gamepad/Button.kt
+++ b/android/src/main/kotlin/com/example/flutter_gamepad/Button.kt
@@ -2,6 +2,9 @@ package com.example.flutter_gamepad
 
 import android.view.KeyEvent
 
+/**
+ * The buttons on a gamepad, in flutter_gamepad order. This order matches the one on the Dart side.
+ */
 enum class Button {
     A,
     B,
@@ -21,15 +24,26 @@ enum class Button {
     RightTrigger,
 }
 
+/**
+ * The thumbsticks on a gamepad, in flutter_gamepad order. This order matches the one on the Dart side.
+ */
+enum class Thumbstick {
+    Left,
+    Right,
+}
+
+/**
+ * A map from Android key-codes to the flutter_gamepad Button enum.
+ */
 val buttonMap = hashMapOf(
         KeyEvent.KEYCODE_BUTTON_A to Button.A,
         KeyEvent.KEYCODE_BUTTON_B to Button.B,
         KeyEvent.KEYCODE_BUTTON_X to Button.X,
         KeyEvent.KEYCODE_BUTTON_Y to Button.Y,
-        // KeyEvent.KEYCODE_DPAD_UP to Button.DpadUp,
-        // KeyEvent.KEYCODE_DPAD_DOWN to Button.DpadDown,
-        // KeyEvent.KEYCODE_DPAD_LEFT to Button.DpadLeft,
-        // KeyEvent.KEYCODE_DPAD_RIGHT to Button.DpadRight,
+        KeyEvent.KEYCODE_DPAD_UP to Button.DpadUp,
+        KeyEvent.KEYCODE_DPAD_DOWN to Button.DpadDown,
+        KeyEvent.KEYCODE_DPAD_LEFT to Button.DpadLeft,
+        KeyEvent.KEYCODE_DPAD_RIGHT to Button.DpadRight,
         KeyEvent.KEYCODE_BUTTON_START to Button.Menu,
         KeyEvent.KEYCODE_BUTTON_SELECT to Button.Options,
         KeyEvent.KEYCODE_BUTTON_THUMBL to Button.LeftThumbstickButton,
@@ -39,8 +53,3 @@ val buttonMap = hashMapOf(
         KeyEvent.KEYCODE_BUTTON_L2 to Button.LeftTrigger,
         KeyEvent.KEYCODE_BUTTON_R2 to Button.RightTrigger
 )
-
-enum class Thumbstick {
-    Left,
-    Right,
-}

--- a/android/src/main/kotlin/com/example/flutter_gamepad/Button.kt
+++ b/android/src/main/kotlin/com/example/flutter_gamepad/Button.kt
@@ -1,0 +1,46 @@
+package com.example.flutter_gamepad
+
+import android.view.KeyEvent
+
+enum class Button {
+    A,
+    B,
+    X,
+    Y,
+    DpadUp,
+    DpadDown,
+    DpadLeft,
+    DpadRight,
+    Menu,
+    Options,
+    LeftThumbstickButton,
+    RightThumbstickButton,
+    LeftShoulder,
+    RightShoulder,
+    LeftTrigger,
+    RightTrigger,
+}
+
+val buttonMap = hashMapOf(
+        KeyEvent.KEYCODE_BUTTON_A to Button.A,
+        KeyEvent.KEYCODE_BUTTON_B to Button.B,
+        KeyEvent.KEYCODE_BUTTON_X to Button.X,
+        KeyEvent.KEYCODE_BUTTON_Y to Button.Y,
+        // KeyEvent.KEYCODE_DPAD_UP to Button.DpadUp,
+        // KeyEvent.KEYCODE_DPAD_DOWN to Button.DpadDown,
+        // KeyEvent.KEYCODE_DPAD_LEFT to Button.DpadLeft,
+        // KeyEvent.KEYCODE_DPAD_RIGHT to Button.DpadRight,
+        KeyEvent.KEYCODE_BUTTON_START to Button.Menu,
+        KeyEvent.KEYCODE_BUTTON_SELECT to Button.Options,
+        KeyEvent.KEYCODE_BUTTON_THUMBL to Button.LeftThumbstickButton,
+        KeyEvent.KEYCODE_BUTTON_THUMBR to Button.RightThumbstickButton,
+        KeyEvent.KEYCODE_BUTTON_L1 to Button.LeftShoulder,
+        KeyEvent.KEYCODE_BUTTON_R1 to Button.RightShoulder,
+        KeyEvent.KEYCODE_BUTTON_L2 to Button.LeftTrigger,
+        KeyEvent.KEYCODE_BUTTON_R2 to Button.RightTrigger
+)
+
+enum class Thumbstick {
+    Left,
+    Right,
+}

--- a/android/src/main/kotlin/com/example/flutter_gamepad/FlutterGamepadPlugin.kt
+++ b/android/src/main/kotlin/com/example/flutter_gamepad/FlutterGamepadPlugin.kt
@@ -3,16 +3,20 @@ package com.example.flutter_gamepad
 import android.os.Build
 import android.util.Log
 import android.view.InputDevice
+import android.view.KeyEvent
 import android.view.MotionEvent
+import io.flutter.embedding.android.AndroidKeyProcessor
 import io.flutter.embedding.android.AndroidTouchProcessor
 import io.flutter.view.FlutterView
 import io.flutter.embedding.engine.renderer.FlutterRenderer
+import io.flutter.embedding.engine.systemchannels.KeyEventChannel
 import io.flutter.plugin.common.EventChannel
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
 import io.flutter.plugin.common.PluginRegistry.Registrar
+import io.flutter.plugin.editing.TextInputPlugin
 
 enum class Button {
     A,
@@ -33,6 +37,25 @@ enum class Button {
     RightTrigger,
 }
 
+val buttonMap = hashMapOf(
+        KeyEvent.KEYCODE_BUTTON_A to Button.A,
+        KeyEvent.KEYCODE_BUTTON_B to Button.B,
+        KeyEvent.KEYCODE_BUTTON_X to Button.X,
+        KeyEvent.KEYCODE_BUTTON_Y to Button.Y,
+        // KeyEvent.KEYCODE_DPAD_UP to Button.DpadUp,
+        // KeyEvent.KEYCODE_DPAD_DOWN to Button.DpadDown,
+        // KeyEvent.KEYCODE_DPAD_LEFT to Button.DpadLeft,
+        // KeyEvent.KEYCODE_DPAD_RIGHT to Button.DpadRight,
+        KeyEvent.KEYCODE_BUTTON_START to Button.Menu,
+        KeyEvent.KEYCODE_BUTTON_SELECT to Button.Options,
+        KeyEvent.KEYCODE_BUTTON_THUMBL to Button.LeftThumbstickButton,
+        KeyEvent.KEYCODE_BUTTON_THUMBR to Button.RightThumbstickButton,
+        KeyEvent.KEYCODE_BUTTON_L1 to Button.LeftShoulder,
+        KeyEvent.KEYCODE_BUTTON_R1 to Button.RightShoulder,
+        KeyEvent.KEYCODE_BUTTON_L2 to Button.LeftTrigger,
+        KeyEvent.KEYCODE_BUTTON_R2 to Button.RightTrigger
+)
+
 enum class Thumbstick {
     Left,
     Right,
@@ -41,9 +64,24 @@ enum class Thumbstick {
 val InputDevice.isGamepad: Boolean
     get() = sources and InputDevice.SOURCE_GAMEPAD == InputDevice.SOURCE_GAMEPAD
 
+/*
+class GamepadState {
+    var axisValues: HashMap<Int, Float> = hashMapOf()
+    fun getAxis(axis: Int) {
+    }
+}
 
-class GamepadStreamHandler : EventChannel.StreamHandler {
+class GamepadCache {
+    var gamepads: HashMap<Int, GamepadState> = hashMapOf()
+    fun axis(gamepadId: Int, axis: Int): Float {
+        gamepads.getOrPut(gamepadId) { GamepadState() }.getAxis(axis)
+    }
+}
+ */
+
+object GamepadStreamHandler : EventChannel.StreamHandler {
     var eventSink: EventChannel.EventSink? = null
+    // var gamepadCache = GamepadCache()
     override fun onListen(arguments: Any?, eventSink: EventChannel.EventSink?) {
         this.eventSink = eventSink
         for (id in InputDevice.getDeviceIds()) {
@@ -77,53 +115,119 @@ class GamepadStreamHandler : EventChannel.StreamHandler {
         ))
     }
 
-    private fun gamepadDisconnected(device: InputDevice) {
-        // TODO
-    }
-
     fun allGamepadInfoDictionaries(): List<HashMap<String, Any>> =
             InputDevice.getDeviceIds()
                     .map(InputDevice::getDevice)
                     .filter { it.isGamepad }
                     .map { gamepadInfoDictionary(it) }
+
+    private fun reportThumbstick(event: MotionEvent, thumbstick: Thumbstick, xAxis: Int, yAxis: Int) {
+        val x = event.getAxisValue(xAxis)
+        val y = event.getAxisValue(yAxis)
+        eventSink?.success(
+                hashMapOf("event" to "thumbstick", "gamepadId" to event.deviceId,
+                        "thumbstick" to thumbstick.ordinal, "x" to x, "y" to y))
+    }
+
+    private fun reportAxisButton(event: MotionEvent, button: Button, axis: Int) {
+        val value = event.getAxisValue(axis)
+        eventSink?.success(
+                hashMapOf("event" to "button", "gamepadId" to event.deviceId,
+                        "button" to button.ordinal, "value" to value))
+    }
+
+//    private fun reportHatAxis(event: MotionEvent, buttonMinus: Button, buttonPlus: Button, axis: Int) {
+//        val value = event.getAxisValue(axis)
+//        eventSink?.success(
+//                hashMapOf("event" to "button", "gamepadId" to event.deviceId,
+//                        "button" to button.ordinal, "value" to value))
+//        )
+//    }
+
+    fun processEvent(event: MotionEvent) {
+        reportThumbstick(event, Thumbstick.Left, MotionEvent.AXIS_X, MotionEvent.AXIS_Y)
+        reportThumbstick(event, Thumbstick.Right, MotionEvent.AXIS_Z, MotionEvent.AXIS_RZ)
+        reportAxisButton(event, Button.LeftTrigger, MotionEvent.AXIS_BRAKE)
+        reportAxisButton(event, Button.RightTrigger, MotionEvent.AXIS_GAS)
+//        reportHatAxis(event, Button.DpadLeft, Button.DpadRight, MotionEvent.AXIS_HAT_X)
+//        reportHatAxis(event, Button.DpadUp, Button.DpadDown, MotionEvent.AXIS_HAT_Y)
+        reportAxisButton(event, Button.A, MotionEvent.AXIS_HAT_X)
+        reportAxisButton(event, Button.B, MotionEvent.AXIS_HAT_Y)
+    }
 }
 
 class GamepadAndroidTouchProcessor(renderer: FlutterRenderer) : AndroidTouchProcessor(renderer) {
     companion object {
-        const val TAG: String = "GamepadAndroidTouchProc";
+        const val TAG: String = "GamepadAndroidTouchPro"
     }
+
     override fun onGenericMotionEvent(event: MotionEvent): Boolean {
-        Log.d(TAG, "${event.action}, ${event.source}, ${Build.VERSION.SDK_INT >= 18 && event.isFromSource(InputDevice.SOURCE_CLASS_JOYSTICK)}")
-        return super.onGenericMotionEvent(event)
+        return if (Build.VERSION.SDK_INT >= 18 && event.isFromSource(InputDevice.SOURCE_CLASS_JOYSTICK) && event.action == MotionEvent.ACTION_MOVE) {
+            GamepadStreamHandler.processEvent(event)
+            true
+        } else {
+            super.onGenericMotionEvent(event)
+        }
+    }
+}
+
+class GamepadAndroidKeyProcessor(keyEventChannel: KeyEventChannel, textInputPlugin: TextInputPlugin) : AndroidKeyProcessor(keyEventChannel, textInputPlugin) {
+    override fun onKeyDown(keyEvent: KeyEvent) {
+        val button = buttonMap[keyEvent.keyCode]
+        if (button != null) {
+            GamepadStreamHandler.eventSink?.success(hashMapOf("event" to "button", "gamepadId" to keyEvent.deviceId, "button" to button.ordinal, "value" to 1.0))
+        } else {
+            return super.onKeyDown(keyEvent)
+        }
+    }
+
+    override fun onKeyUp(keyEvent: KeyEvent) {
+        val button = buttonMap[keyEvent.keyCode]
+        if (button != null) {
+            GamepadStreamHandler.eventSink?.success(hashMapOf("event" to "button", "gamepadId" to keyEvent.deviceId, "button" to button.ordinal, "value" to 0.0))
+        } else {
+            return super.onKeyDown(keyEvent)
+        }
     }
 }
 
 class FlutterGamepadPlugin : MethodCallHandler {
     companion object {
-        val gamepadStreamHandler: GamepadStreamHandler = GamepadStreamHandler()
-
         @JvmStatic
         fun registerWith(registrar: Registrar) {
             val methodChannel = MethodChannel(registrar.messenger(), "com.rainway.flutter_gamepad/methods")
             methodChannel.setMethodCallHandler(FlutterGamepadPlugin())
             val eventChannel = EventChannel(registrar.messenger(), "com.rainway.flutter_gamepad/events")
-            eventChannel.setStreamHandler(gamepadStreamHandler)
+            eventChannel.setStreamHandler(GamepadStreamHandler)
+
+            val view: FlutterView = registrar.view()
 
             // Hack: swap in a new AndroidTouchProcessor.
-            val view: FlutterView = registrar.view()
             val touchProcessorField = FlutterView::class.java.getDeclaredField("androidTouchProcessor")
+            touchProcessorField.isAccessible = true
             val rendererField = FlutterView::class.java.getDeclaredField("flutterRenderer")
             rendererField.isAccessible = true
             val renderer = rendererField.get(view) as FlutterRenderer
-            touchProcessorField.isAccessible = true
             val touchProcessor = GamepadAndroidTouchProcessor(renderer)
-            touchProcessorField.set(registrar.view(), touchProcessor)
+            touchProcessorField.set(view, touchProcessor)
+
+            // Hack: swap in a new AndroidKeyProcessor.
+            val keyProcessorField = FlutterView::class.java.getDeclaredField("androidKeyProcessor")
+            keyProcessorField.isAccessible = true
+            val keyEventChannelField = FlutterView::class.java.getDeclaredField("keyEventChannel")
+            keyEventChannelField.isAccessible = true
+            val textInputPluginField = FlutterView::class.java.getDeclaredField("mTextInputPlugin")
+            textInputPluginField.isAccessible = true
+            val keyEventChannel = keyEventChannelField.get(view) as KeyEventChannel
+            val textInputPlugin = textInputPluginField.get(view) as TextInputPlugin
+            val keyProcessor = GamepadAndroidKeyProcessor(keyEventChannel, textInputPlugin)
+            keyProcessorField.set(view, keyProcessor)
         }
     }
 
     override fun onMethodCall(call: MethodCall, result: Result) {
         if (call.method == "gamepads") {
-            result.success(gamepadStreamHandler.allGamepadInfoDictionaries())
+            result.success(GamepadStreamHandler.allGamepadInfoDictionaries())
         } else {
             result.notImplemented()
         }

--- a/android/src/main/kotlin/com/example/flutter_gamepad/FlutterGamepadPlugin.kt
+++ b/android/src/main/kotlin/com/example/flutter_gamepad/FlutterGamepadPlugin.kt
@@ -18,6 +18,7 @@ import java.lang.reflect.Field
 
 /**
  * An extension of Flutter's AndroidTouchProcessor that delegates MotionEvents to the GamepadStreamHandler.
+ * (On Android, thumbstick events from a gamepad are a kind of MotionEvent.)
  */
 class GamepadAndroidTouchProcessor(renderer: FlutterRenderer) : AndroidTouchProcessor(renderer) {
     override fun onGenericMotionEvent(event: MotionEvent): Boolean {
@@ -27,6 +28,7 @@ class GamepadAndroidTouchProcessor(renderer: FlutterRenderer) : AndroidTouchProc
 
 /**
  * An extension of Flutter's AndroidKeyProcessor that delegates KeyEvents to the GamepadStreamHandler.
+ * (On Android, button events from a gamepad are a kind of KeyEvent.)
  */
 class GamepadAndroidKeyProcessor(keyEventChannel: KeyEventChannel, textInputPlugin: TextInputPlugin) : AndroidKeyProcessor(keyEventChannel, textInputPlugin) {
     override fun onKeyDown(keyEvent: KeyEvent) {

--- a/android/src/main/kotlin/com/example/flutter_gamepad/FlutterGamepadPlugin.kt
+++ b/android/src/main/kotlin/com/example/flutter_gamepad/FlutterGamepadPlugin.kt
@@ -1,25 +1,131 @@
 package com.example.flutter_gamepad
 
+import android.os.Build
+import android.util.Log
+import android.view.InputDevice
+import android.view.MotionEvent
+import io.flutter.embedding.android.AndroidTouchProcessor
+import io.flutter.view.FlutterView
+import io.flutter.embedding.engine.renderer.FlutterRenderer
+import io.flutter.plugin.common.EventChannel
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
 import io.flutter.plugin.common.PluginRegistry.Registrar
 
-class FlutterGamepadPlugin: MethodCallHandler {
-  companion object {
-    @JvmStatic
-    fun registerWith(registrar: Registrar) {
-      val channel = MethodChannel(registrar.messenger(), "flutter_gamepad")
-      channel.setMethodCallHandler(FlutterGamepadPlugin())
-    }
-  }
+enum class Button {
+    A,
+    B,
+    X,
+    Y,
+    DpadUp,
+    DpadDown,
+    DpadLeft,
+    DpadRight,
+    Menu,
+    Options,
+    LeftThumbstickButton,
+    RightThumbstickButton,
+    LeftShoulder,
+    RightShoulder,
+    LeftTrigger,
+    RightTrigger,
+}
 
-  override fun onMethodCall(call: MethodCall, result: Result) {
-    if (call.method == "getPlatformVersion") {
-      result.success("Android ${android.os.Build.VERSION.RELEASE}")
-    } else {
-      result.notImplemented()
+enum class Thumbstick {
+    Left,
+    Right,
+}
+
+val InputDevice.isGamepad: Boolean
+    get() = sources and InputDevice.SOURCE_GAMEPAD == InputDevice.SOURCE_GAMEPAD
+
+
+class GamepadStreamHandler : EventChannel.StreamHandler {
+    var eventSink: EventChannel.EventSink? = null
+    override fun onListen(arguments: Any?, eventSink: EventChannel.EventSink?) {
+        this.eventSink = eventSink
+        for (id in InputDevice.getDeviceIds()) {
+            val device = InputDevice.getDevice(id)
+            if (device.isGamepad) {
+                this.gamepadConnected(device)
+            }
+        }
     }
-  }
+
+    override fun onCancel(p0: Any?) {
+        this.eventSink = null //To change body of created functions use File | Settings | File Templates.
+    }
+
+    private fun gamepadInfoDictionary(device: InputDevice): HashMap<String, Any> {
+        val gamepadInfo: HashMap<String, Any> = HashMap()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            gamepadInfo["isAttachedToDevice"] = !device.isExternal
+        }
+        gamepadInfo["vendorName"] = device.name
+        gamepadInfo["productCategory"] = "Android Gamepad"
+        gamepadInfo["id"] = device.id
+        return gamepadInfo
+    }
+
+    private fun gamepadConnected(device: InputDevice) {
+        eventSink?.success(hashMapOf(
+                "event" to "gamepadConnected",
+                "gamepadId" to device.id,
+                "gamepadInfo" to gamepadInfoDictionary(device)
+        ))
+    }
+
+    private fun gamepadDisconnected(device: InputDevice) {
+        // TODO
+    }
+
+    fun allGamepadInfoDictionaries(): List<HashMap<String, Any>> =
+            InputDevice.getDeviceIds()
+                    .map(InputDevice::getDevice)
+                    .filter { it.isGamepad }
+                    .map { gamepadInfoDictionary(it) }
+}
+
+class GamepadAndroidTouchProcessor(renderer: FlutterRenderer) : AndroidTouchProcessor(renderer) {
+    companion object {
+        const val TAG: String = "GamepadAndroidTouchProc";
+    }
+    override fun onGenericMotionEvent(event: MotionEvent): Boolean {
+        Log.d(TAG, "${event.action}, ${event.source}, ${Build.VERSION.SDK_INT >= 18 && event.isFromSource(InputDevice.SOURCE_CLASS_JOYSTICK)}")
+        return super.onGenericMotionEvent(event)
+    }
+}
+
+class FlutterGamepadPlugin : MethodCallHandler {
+    companion object {
+        val gamepadStreamHandler: GamepadStreamHandler = GamepadStreamHandler()
+
+        @JvmStatic
+        fun registerWith(registrar: Registrar) {
+            val methodChannel = MethodChannel(registrar.messenger(), "com.rainway.flutter_gamepad/methods")
+            methodChannel.setMethodCallHandler(FlutterGamepadPlugin())
+            val eventChannel = EventChannel(registrar.messenger(), "com.rainway.flutter_gamepad/events")
+            eventChannel.setStreamHandler(gamepadStreamHandler)
+
+            // Hack: swap in a new AndroidTouchProcessor.
+            val view: FlutterView = registrar.view()
+            val touchProcessorField = FlutterView::class.java.getDeclaredField("androidTouchProcessor")
+            val rendererField = FlutterView::class.java.getDeclaredField("flutterRenderer")
+            rendererField.isAccessible = true
+            val renderer = rendererField.get(view) as FlutterRenderer
+            touchProcessorField.isAccessible = true
+            val touchProcessor = GamepadAndroidTouchProcessor(renderer)
+            touchProcessorField.set(registrar.view(), touchProcessor)
+        }
+    }
+
+    override fun onMethodCall(call: MethodCall, result: Result) {
+        if (call.method == "gamepads") {
+            result.success(gamepadStreamHandler.allGamepadInfoDictionaries())
+        } else {
+            result.notImplemented()
+        }
+    }
 }

--- a/android/src/main/kotlin/com/example/flutter_gamepad/FlutterGamepadPlugin.kt
+++ b/android/src/main/kotlin/com/example/flutter_gamepad/FlutterGamepadPlugin.kt
@@ -1,8 +1,5 @@
 package com.example.flutter_gamepad
 
-import android.os.Build
-import android.util.Log
-import android.view.InputDevice
 import android.view.KeyEvent
 import android.view.MotionEvent
 import io.flutter.embedding.android.AndroidKeyProcessor
@@ -18,175 +15,24 @@ import io.flutter.plugin.common.MethodChannel.Result
 import io.flutter.plugin.common.PluginRegistry.Registrar
 import io.flutter.plugin.editing.TextInputPlugin
 
-enum class Button {
-    A,
-    B,
-    X,
-    Y,
-    DpadUp,
-    DpadDown,
-    DpadLeft,
-    DpadRight,
-    Menu,
-    Options,
-    LeftThumbstickButton,
-    RightThumbstickButton,
-    LeftShoulder,
-    RightShoulder,
-    LeftTrigger,
-    RightTrigger,
-}
-
-val buttonMap = hashMapOf(
-        KeyEvent.KEYCODE_BUTTON_A to Button.A,
-        KeyEvent.KEYCODE_BUTTON_B to Button.B,
-        KeyEvent.KEYCODE_BUTTON_X to Button.X,
-        KeyEvent.KEYCODE_BUTTON_Y to Button.Y,
-        // KeyEvent.KEYCODE_DPAD_UP to Button.DpadUp,
-        // KeyEvent.KEYCODE_DPAD_DOWN to Button.DpadDown,
-        // KeyEvent.KEYCODE_DPAD_LEFT to Button.DpadLeft,
-        // KeyEvent.KEYCODE_DPAD_RIGHT to Button.DpadRight,
-        KeyEvent.KEYCODE_BUTTON_START to Button.Menu,
-        KeyEvent.KEYCODE_BUTTON_SELECT to Button.Options,
-        KeyEvent.KEYCODE_BUTTON_THUMBL to Button.LeftThumbstickButton,
-        KeyEvent.KEYCODE_BUTTON_THUMBR to Button.RightThumbstickButton,
-        KeyEvent.KEYCODE_BUTTON_L1 to Button.LeftShoulder,
-        KeyEvent.KEYCODE_BUTTON_R1 to Button.RightShoulder,
-        KeyEvent.KEYCODE_BUTTON_L2 to Button.LeftTrigger,
-        KeyEvent.KEYCODE_BUTTON_R2 to Button.RightTrigger
-)
-
-enum class Thumbstick {
-    Left,
-    Right,
-}
-
-val InputDevice.isGamepad: Boolean
-    get() = sources and InputDevice.SOURCE_GAMEPAD == InputDevice.SOURCE_GAMEPAD
-
-/*
-class GamepadState {
-    var axisValues: HashMap<Int, Float> = hashMapOf()
-    fun getAxis(axis: Int) {
-    }
-}
-
-class GamepadCache {
-    var gamepads: HashMap<Int, GamepadState> = hashMapOf()
-    fun axis(gamepadId: Int, axis: Int): Float {
-        gamepads.getOrPut(gamepadId) { GamepadState() }.getAxis(axis)
-    }
-}
- */
-
-object GamepadStreamHandler : EventChannel.StreamHandler {
-    var eventSink: EventChannel.EventSink? = null
-    // var gamepadCache = GamepadCache()
-    override fun onListen(arguments: Any?, eventSink: EventChannel.EventSink?) {
-        this.eventSink = eventSink
-        for (id in InputDevice.getDeviceIds()) {
-            val device = InputDevice.getDevice(id)
-            if (device.isGamepad) {
-                this.gamepadConnected(device)
-            }
-        }
-    }
-
-    override fun onCancel(p0: Any?) {
-        this.eventSink = null //To change body of created functions use File | Settings | File Templates.
-    }
-
-    private fun gamepadInfoDictionary(device: InputDevice): HashMap<String, Any> {
-        val gamepadInfo: HashMap<String, Any> = HashMap()
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            gamepadInfo["isAttachedToDevice"] = !device.isExternal
-        }
-        gamepadInfo["vendorName"] = device.name
-        gamepadInfo["productCategory"] = "Android Gamepad"
-        gamepadInfo["id"] = device.id
-        return gamepadInfo
-    }
-
-    private fun gamepadConnected(device: InputDevice) {
-        eventSink?.success(hashMapOf(
-                "event" to "gamepadConnected",
-                "gamepadId" to device.id,
-                "gamepadInfo" to gamepadInfoDictionary(device)
-        ))
-    }
-
-    fun allGamepadInfoDictionaries(): List<HashMap<String, Any>> =
-            InputDevice.getDeviceIds()
-                    .map(InputDevice::getDevice)
-                    .filter { it.isGamepad }
-                    .map { gamepadInfoDictionary(it) }
-
-    private fun reportThumbstick(event: MotionEvent, thumbstick: Thumbstick, xAxis: Int, yAxis: Int) {
-        val x = event.getAxisValue(xAxis)
-        val y = event.getAxisValue(yAxis)
-        eventSink?.success(
-                hashMapOf("event" to "thumbstick", "gamepadId" to event.deviceId,
-                        "thumbstick" to thumbstick.ordinal, "x" to x, "y" to y))
-    }
-
-    private fun reportAxisButton(event: MotionEvent, button: Button, axis: Int) {
-        val value = event.getAxisValue(axis)
-        eventSink?.success(
-                hashMapOf("event" to "button", "gamepadId" to event.deviceId,
-                        "button" to button.ordinal, "value" to value))
-    }
-
-//    private fun reportHatAxis(event: MotionEvent, buttonMinus: Button, buttonPlus: Button, axis: Int) {
-//        val value = event.getAxisValue(axis)
-//        eventSink?.success(
-//                hashMapOf("event" to "button", "gamepadId" to event.deviceId,
-//                        "button" to button.ordinal, "value" to value))
-//        )
-//    }
-
-    fun processEvent(event: MotionEvent) {
-        reportThumbstick(event, Thumbstick.Left, MotionEvent.AXIS_X, MotionEvent.AXIS_Y)
-        reportThumbstick(event, Thumbstick.Right, MotionEvent.AXIS_Z, MotionEvent.AXIS_RZ)
-        reportAxisButton(event, Button.LeftTrigger, MotionEvent.AXIS_BRAKE)
-        reportAxisButton(event, Button.RightTrigger, MotionEvent.AXIS_GAS)
-//        reportHatAxis(event, Button.DpadLeft, Button.DpadRight, MotionEvent.AXIS_HAT_X)
-//        reportHatAxis(event, Button.DpadUp, Button.DpadDown, MotionEvent.AXIS_HAT_Y)
-        reportAxisButton(event, Button.A, MotionEvent.AXIS_HAT_X)
-        reportAxisButton(event, Button.B, MotionEvent.AXIS_HAT_Y)
-    }
-}
-
 class GamepadAndroidTouchProcessor(renderer: FlutterRenderer) : AndroidTouchProcessor(renderer) {
-    companion object {
-        const val TAG: String = "GamepadAndroidTouchPro"
-    }
-
     override fun onGenericMotionEvent(event: MotionEvent): Boolean {
-        return if (Build.VERSION.SDK_INT >= 18 && event.isFromSource(InputDevice.SOURCE_CLASS_JOYSTICK) && event.action == MotionEvent.ACTION_MOVE) {
-            GamepadStreamHandler.processEvent(event)
-            true
-        } else {
-            super.onGenericMotionEvent(event)
-        }
+        return GamepadStreamHandler.processMotionEvent(event) || super.onGenericMotionEvent(event)
     }
 }
 
 class GamepadAndroidKeyProcessor(keyEventChannel: KeyEventChannel, textInputPlugin: TextInputPlugin) : AndroidKeyProcessor(keyEventChannel, textInputPlugin) {
     override fun onKeyDown(keyEvent: KeyEvent) {
-        val button = buttonMap[keyEvent.keyCode]
-        if (button != null) {
-            GamepadStreamHandler.eventSink?.success(hashMapOf("event" to "button", "gamepadId" to keyEvent.deviceId, "button" to button.ordinal, "value" to 1.0))
-        } else {
-            return super.onKeyDown(keyEvent)
+        val handled = GamepadStreamHandler.processKeyDownEvent(keyEvent)
+        if (!handled) {
+            super.onKeyDown(keyEvent)
         }
     }
 
     override fun onKeyUp(keyEvent: KeyEvent) {
-        val button = buttonMap[keyEvent.keyCode]
-        if (button != null) {
-            GamepadStreamHandler.eventSink?.success(hashMapOf("event" to "button", "gamepadId" to keyEvent.deviceId, "button" to button.ordinal, "value" to 0.0))
-        } else {
-            return super.onKeyDown(keyEvent)
+        val handled = GamepadStreamHandler.processKeyUpEvent(keyEvent)
+        if (!handled) {
+            super.onKeyDown(keyEvent)
         }
     }
 }

--- a/android/src/main/kotlin/com/example/flutter_gamepad/GamepadCache.kt
+++ b/android/src/main/kotlin/com/example/flutter_gamepad/GamepadCache.kt
@@ -60,11 +60,8 @@ class GamepadState(val eventSink: EventChannel.EventSink, val deviceId: Int) {
     }
 
     private fun normalize(value: Float): Float {
-        return if (value.absoluteValue < AXIS_THRESHOLD) {
-            0.0f
-        } else {
-            value
-        }
+        return if (value.absoluteValue < AXIS_THRESHOLD) 0.0f else value
+
     }
 
     fun handleThumbstick(event: MotionEvent, thumbstick: Thumbstick, xAxis: Int, yAxis: Int) {

--- a/android/src/main/kotlin/com/example/flutter_gamepad/GamepadCache.kt
+++ b/android/src/main/kotlin/com/example/flutter_gamepad/GamepadCache.kt
@@ -1,0 +1,195 @@
+package com.example.flutter_gamepad
+
+import android.os.Build
+import android.view.InputDevice
+import android.view.KeyEvent
+import android.view.MotionEvent
+import io.flutter.plugin.common.EventChannel
+import kotlin.math.absoluteValue
+
+val MotionEvent.isJoystickMove: Boolean
+    get() = Build.VERSION.SDK_INT >= 18 && isFromSource(InputDevice.SOURCE_CLASS_JOYSTICK) && action == MotionEvent.ACTION_MOVE
+
+/**
+ * Axis values with absolute value less than this constant are mapped to 0.
+ */
+const val AXIS_THRESHOLD: Float = 0.01f
+
+/**
+ * A "smart" snapshot of the current state (axis positions) for one gamepad.
+ *
+ * It knows how to send events to Flutter, over the given eventSink.
+ *
+ * This class is also in charge of "forgetting" the exact position of an axis that's sufficiently
+ * close to 0. Such positions are snapped exactly to 0, so that not every slight spurious movement
+ * of a controller stick causes events to be fired.
+ *
+ * ## Why only keep axis values?
+ *
+ * We actually don't need to remember button positions, because we get e.g. "A down" and "A up"
+ * events that we can always trust for those. But a motion event doesn't tell us which sticks
+ * or axes have changed, and this class handles that.
+ *
+ * The exception is the D-pad. If a KEYCODE_DPAD_LEFT key-down event comes in, we obey it.
+ * But some gamepads report D-pad inputs on the AXIS_HAT_X and AXIS_HAT_Y axes.
+ * We treat HAT_X and HAT_Y as "axes that can also be steered by key events."
+ */
+class GamepadState(val eventSink: EventChannel.EventSink, val deviceId: Int) {
+    /** A map from axis numbers (e.g. MotionEvent.AXIS_HAT_X) to their floating-point readings. */
+    private var axisValues = HashMap<Int, Float>()
+
+    private fun axisValue(axis: Int): Float {
+        val value = axisValues[axis] ?: 0.0f
+        axisValues[axis] = value
+        return value
+    }
+
+    /** When a GamepadState is created, send a `gamepadConnected` event to Flutter.
+     *
+     * Android doesn't have an event for "a new controller was connected", but the lazy and
+     * memoized nature of `GamepadCache` means this will happen once, the first time any gamepad
+     * event for a new controller is seen.
+     */
+    init {
+        sendEvent("event" to "gamepadConnected",
+                "gamepadInfo" to gamepadInfoDictionary(InputDevice.getDevice(deviceId)))
+    }
+
+    private fun sendEvent(vararg pairs: Pair<String, Any>) {
+        eventSink.success(hashMapOf("gamepadId" to deviceId, *pairs))
+    }
+
+    private fun normalize(value: Float): Float {
+        return if (value.absoluteValue < AXIS_THRESHOLD) {
+            0.0f
+        } else {
+            value
+        }
+    }
+
+    fun handleThumbstick(event: MotionEvent, thumbstick: Thumbstick, xAxis: Int, yAxis: Int) {
+        val x = normalize(event.getAxisValue(xAxis))
+        val y = normalize(event.getAxisValue(yAxis))
+        if (axisValue(xAxis) != x || axisValue(yAxis) != y) {
+            sendEvent("event" to "thumbstick", "thumbstick" to thumbstick.ordinal, "x" to x, "y" to y)
+        }
+        axisValues[xAxis] = x
+        axisValues[yAxis] = y
+    }
+
+    fun handleAxisButton(event: MotionEvent, button: Button, axis: Int) {
+        val value = normalize(event.getAxisValue(axis))
+        if (axisValue(axis) != value) {
+            sendEvent("event" to "button", "button" to button.ordinal, "value" to value)
+        }
+        axisValues[axis] = value
+    }
+
+    fun handleHatAxis(event: MotionEvent, buttonMinus: Button, buttonPlus: Button, axis: Int) {
+        val new = normalize(event.getAxisValue(axis))
+        val old = axisValue(axis)
+
+        val wasPlus = old > 0.0f
+        val nowPlus = new > 0.0f
+        if (!wasPlus && nowPlus) {
+            sendEvent("event" to "button", "button" to buttonPlus.ordinal, "value" to 1.0f)
+        } else if (wasPlus && !nowPlus) {
+            sendEvent("event" to "button", "button" to buttonPlus.ordinal, "value" to 0.0f)
+        }
+
+        val wasMinus = old < 0.0f
+        val nowMinus = new < 0.0f
+        if (!wasMinus && nowMinus) {
+            sendEvent("event" to "button", "button" to buttonMinus.ordinal, "value" to 1.0f)
+        } else if (wasMinus && !nowMinus) {
+            sendEvent("event" to "button", "button" to buttonMinus.ordinal, "value" to 0.0f)
+        }
+
+        axisValues[axis] = new
+    }
+
+    fun buttonDown(button: Button) {
+        // D-pad buttons affect the hat axis values:
+        if (button == Button.DpadLeft) axisValues[MotionEvent.AXIS_HAT_X] = -1.0f
+        if (button == Button.DpadRight) axisValues[MotionEvent.AXIS_HAT_X] = +1.0f
+        if (button == Button.DpadUp) axisValues[MotionEvent.AXIS_HAT_Y] = -1.0f
+        if (button == Button.DpadDown) axisValues[MotionEvent.AXIS_HAT_Y] = +1.0f
+
+        sendEvent("event" to "button", "button" to button.ordinal, "value" to 1.0f)
+    }
+
+    fun buttonUp(button: Button) {
+        // D-pad buttons affect the hat axis values:
+        if (button == Button.DpadLeft || button == Button.DpadRight) axisValues[MotionEvent.AXIS_HAT_X] = 0.0f
+        if (button == Button.DpadUp || button == Button.DpadDown) axisValues[MotionEvent.AXIS_HAT_Y] = 0.0f
+
+        sendEvent("event" to "button", "button" to button.ordinal, "value" to 0.0f)
+    }
+}
+
+/**
+ * A GamepadCache is fed gamepad data from the OS. It remembers the current position
+ * of each gamepad's joysticks and handles changes to the EventSink passed in on creation.
+ */
+class GamepadCache(val eventSink: EventChannel.EventSink) {
+    val gamepadStates = HashMap<Int, GamepadState>()
+
+    private fun gamepadState(deviceId: Int): GamepadState {
+        val state = gamepadStates[deviceId] ?: GamepadState(eventSink, deviceId)
+        gamepadStates[deviceId] = state
+        return state
+    }
+
+    /**
+     * Process a generic motion Android event. Returns true if the event was handled successfully,
+     * or false if it should be bubbled up.
+     */
+    fun processMotionEvent(event: MotionEvent): Boolean {
+        if (event.isJoystickMove) {
+            val state = gamepadState(event.deviceId)
+            state.handleThumbstick(event, Thumbstick.Left, MotionEvent.AXIS_X, MotionEvent.AXIS_Y)
+            state.handleThumbstick(event, Thumbstick.Right, MotionEvent.AXIS_Z, MotionEvent.AXIS_RZ)
+            state.handleAxisButton(event, Button.LeftTrigger, MotionEvent.AXIS_BRAKE)
+            state.handleAxisButton(event, Button.RightTrigger, MotionEvent.AXIS_GAS)
+            state.handleHatAxis(event, Button.DpadLeft, Button.DpadRight, MotionEvent.AXIS_HAT_X)
+            state.handleHatAxis(event, Button.DpadUp, Button.DpadDown, MotionEvent.AXIS_HAT_Y)
+            return true
+        }
+        return false
+    }
+
+    /**
+     * Process a "key down" Android event. Returns true if the event was handled successfully,
+     * or false if it should be bubbled up.
+     */
+    fun processKeyDownEvent(keyEvent: KeyEvent): Boolean {
+        val button = buttonMap[keyEvent.keyCode]
+        if (button != null) {
+            gamepadState(keyEvent.deviceId).buttonDown(button)
+            return true
+        }
+        return false
+    }
+
+    /**
+     * Process a "key up" Android event. Returns true if the event was handled successfully,
+     * or false if it should be bubbled up.
+     */
+    fun processKeyUpEvent(keyEvent: KeyEvent): Boolean {
+        val state = gamepadState(keyEvent.deviceId)
+        val button = buttonMap[keyEvent.keyCode]
+        if (button != null) {
+            state.buttonUp(button)
+            return true
+        }
+        return false
+    }
+
+    /**
+     * Create a gamepad state object if necessary, but do nothing with it.
+     * If a new gamepad state object is created, this sends a "gamepad connected" event to Flutter.
+     */
+    fun touchGamepad(deviceId: Int) {
+        gamepadState(deviceId)
+    }
+}

--- a/android/src/main/kotlin/com/example/flutter_gamepad/GamepadInfo.kt
+++ b/android/src/main/kotlin/com/example/flutter_gamepad/GamepadInfo.kt
@@ -1,0 +1,19 @@
+package com.example.flutter_gamepad
+
+import android.os.Build
+import android.view.InputDevice
+
+fun gamepadInfoDictionary(device: InputDevice): HashMap<String, Any?> {
+    val isAttached = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        !device.isExternal
+    } else {
+        null
+    }
+
+    return hashMapOf(
+            "isAttachedToDevice" to isAttached,
+            "vendorName" to device.name,
+            "productCategory" to "Android Gamepad",
+            "id" to device.id
+    )
+}

--- a/android/src/main/kotlin/com/example/flutter_gamepad/GamepadInfo.kt
+++ b/android/src/main/kotlin/com/example/flutter_gamepad/GamepadInfo.kt
@@ -3,12 +3,10 @@ package com.example.flutter_gamepad
 import android.os.Build
 import android.view.InputDevice
 
-fun gamepadInfoDictionary(device: InputDevice): HashMap<String, Any?> {
-    val isAttached = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-        !device.isExternal
-    } else {
-        null
-    }
+typealias GamepadInfo = HashMap<String, Any?>
+
+fun gamepadInfoDictionary(device: InputDevice): GamepadInfo {
+    val isAttached = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) !device.isExternal else null
 
     return hashMapOf(
             "isAttachedToDevice" to isAttached,
@@ -16,4 +14,11 @@ fun gamepadInfoDictionary(device: InputDevice): HashMap<String, Any?> {
             "productCategory" to "Android Gamepad",
             "id" to device.id
     )
+}
+
+fun allGamepadInfoDictionaries(): List<GamepadInfo> {
+    return InputDevice.getDeviceIds()
+            .map(InputDevice::getDevice)
+            .filter { it.isGamepad }
+            .map { gamepadInfoDictionary(it) }
 }

--- a/android/src/main/kotlin/com/example/flutter_gamepad/GamepadStreamHandler.kt
+++ b/android/src/main/kotlin/com/example/flutter_gamepad/GamepadStreamHandler.kt
@@ -1,6 +1,5 @@
 package com.example.flutter_gamepad
 
-import android.os.Build
 import android.view.InputDevice
 import android.view.KeyEvent
 import android.view.MotionEvent
@@ -9,11 +8,13 @@ import io.flutter.plugin.common.EventChannel
 val InputDevice.isGamepad: Boolean
     get() = sources and InputDevice.SOURCE_GAMEPAD == InputDevice.SOURCE_GAMEPAD
 
+/**
+ * A singleton object that manages the gamepad event stream. It is fed Android events and
+ * redirects the gamepad ones into a Flutter EventSink via its GamepadCache.
+ */
 object GamepadStreamHandler : EventChannel.StreamHandler {
-    private var eventSink: EventChannel.EventSink? = null
     private var gamepadCache: GamepadCache? = null
     override fun onListen(arguments: Any?, eventSink: EventChannel.EventSink?) {
-        this.eventSink = eventSink
         this.gamepadCache = GamepadCache(eventSink!!)
         for (id in InputDevice.getDeviceIds()) {
             val device = InputDevice.getDevice(id)
@@ -24,15 +25,8 @@ object GamepadStreamHandler : EventChannel.StreamHandler {
     }
 
     override fun onCancel(arguments: Any?) {
-        this.eventSink = null
         this.gamepadCache = null
     }
-
-    fun allGamepadInfoDictionaries(): List<HashMap<String, Any?>> =
-            InputDevice.getDeviceIds()
-                    .map(InputDevice::getDevice)
-                    .filter { it.isGamepad }
-                    .map { gamepadInfoDictionary(it) }
 
     // Returns true if the cache handled the event, or false if it should be bubbled up.
     fun processMotionEvent(event: MotionEvent): Boolean {

--- a/android/src/main/kotlin/com/example/flutter_gamepad/GamepadStreamHandler.kt
+++ b/android/src/main/kotlin/com/example/flutter_gamepad/GamepadStreamHandler.kt
@@ -1,0 +1,51 @@
+package com.example.flutter_gamepad
+
+import android.os.Build
+import android.view.InputDevice
+import android.view.KeyEvent
+import android.view.MotionEvent
+import io.flutter.plugin.common.EventChannel
+
+val InputDevice.isGamepad: Boolean
+    get() = sources and InputDevice.SOURCE_GAMEPAD == InputDevice.SOURCE_GAMEPAD
+
+object GamepadStreamHandler : EventChannel.StreamHandler {
+    private var eventSink: EventChannel.EventSink? = null
+    private var gamepadCache: GamepadCache? = null
+    override fun onListen(arguments: Any?, eventSink: EventChannel.EventSink?) {
+        this.eventSink = eventSink
+        this.gamepadCache = GamepadCache(eventSink!!)
+        for (id in InputDevice.getDeviceIds()) {
+            val device = InputDevice.getDevice(id)
+            if (device.isGamepad) {
+                gamepadCache!!.touchGamepad(id)
+            }
+        }
+    }
+
+    override fun onCancel(arguments: Any?) {
+        this.eventSink = null
+        this.gamepadCache = null
+    }
+
+    fun allGamepadInfoDictionaries(): List<HashMap<String, Any?>> =
+            InputDevice.getDeviceIds()
+                    .map(InputDevice::getDevice)
+                    .filter { it.isGamepad }
+                    .map { gamepadInfoDictionary(it) }
+
+    // Returns true if the cache handled the event, or false if it should be bubbled up.
+    fun processMotionEvent(event: MotionEvent): Boolean {
+        return gamepadCache != null && gamepadCache!!.processMotionEvent(event)
+    }
+
+    // Returns true if the cache handled the event, or false if it should be bubbled up.
+    fun processKeyDownEvent(keyEvent: KeyEvent): Boolean {
+        return gamepadCache != null && gamepadCache!!.processKeyDownEvent(keyEvent)
+    }
+
+    // Returns true if the cache handled the event, or false if it should be bubbled up.
+    fun processKeyUpEvent(keyEvent: KeyEvent): Boolean {
+        return gamepadCache != null && gamepadCache!!.processKeyUpEvent(keyEvent)
+    }
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -72,11 +72,12 @@ class _MyAppState extends State<MyApp> {
         ),
         body: Center(
           child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
             children: [
               Text('Running on: ${Theme.of(context).platform}\n' +
                   _eventLog.map(_describeEvent).toList().join('\n')),
               RaisedButton(onPressed: _fetchGamepads, child: Text('Call gamepads()')),
-              Text('gamepads = $_gamepads'),
+              Text('gamepads = ${_gamepads?.map((pad) => pad.vendorName)}'),
             ],
           ),
         ),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -66,19 +66,22 @@ class _MyAppState extends State<MyApp> {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      home: Scaffold(
-        appBar: AppBar(
-          title: const Text('Plugin example app'),
-        ),
-        body: Center(
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              Text('Running on: ${Theme.of(context).platform}\n' +
-                  _eventLog.map(_describeEvent).toList().join('\n')),
-              RaisedButton(onPressed: _fetchGamepads, child: Text('Call gamepads()')),
-              Text('gamepads = ${_gamepads?.map((pad) => pad.vendorName)}'),
-            ],
+      home: WillPopScope(
+        onWillPop: () async => false,
+        child: Scaffold(
+          appBar: AppBar(
+            title: const Text('Plugin example app'),
+          ),
+          body: Center(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Text('Running on: ${Theme.of(context).platform}\n' +
+                    _eventLog.map(_describeEvent).toList().join('\n')),
+                RaisedButton(onPressed: _fetchGamepads, child: Text('Call gamepads()')),
+                Text('gamepads = ${_gamepads?.map((pad) => pad.vendorName)}'),
+              ],
+            ),
           ),
         ),
       ),

--- a/ios/Classes/SwiftFlutterGamepadPlugin.swift
+++ b/ios/Classes/SwiftFlutterGamepadPlugin.swift
@@ -111,22 +111,22 @@ enum Thumbstick : Int {
     gamepad.buttonY.valueChangedHandler = buttonHandler(.y)
     if #available(iOS 13.0, *) {
       gamepad.buttonOptions?.valueChangedHandler = buttonHandler(.options)
-        gamepad.buttonMenu.valueChangedHandler = buttonHandler(.menu)
+      gamepad.buttonMenu.valueChangedHandler = buttonHandler(.menu)
     } else {
       gamepad.controller?.controllerPausedHandler = { (_) in
         eventSink(["event": "button", "gamepadId": gamepad.hash, "button": Button.menu.rawValue, "value": 1.0])
         eventSink(["event": "button", "gamepadId": gamepad.hash, "button": Button.menu.rawValue, "value": 0.0])
       }
     }
-          gamepad.leftShoulder.valueChangedHandler = buttonHandler(.leftShoulder)
-          gamepad.leftTrigger.valueChangedHandler = buttonHandler(.leftTrigger)
-          gamepad.rightShoulder.valueChangedHandler = buttonHandler(.rightShoulder)
-          gamepad.rightTrigger.valueChangedHandler = buttonHandler(.rightTrigger)
-          gamepad.dpad.up.valueChangedHandler = buttonHandler(.dpadUp)
-          gamepad.dpad.down.valueChangedHandler = buttonHandler(.dpadDown)
+    gamepad.leftShoulder.valueChangedHandler = buttonHandler(.leftShoulder)
+    gamepad.leftTrigger.valueChangedHandler = buttonHandler(.leftTrigger)
+    gamepad.rightShoulder.valueChangedHandler = buttonHandler(.rightShoulder)
+    gamepad.rightTrigger.valueChangedHandler = buttonHandler(.rightTrigger)
+    gamepad.dpad.up.valueChangedHandler = buttonHandler(.dpadUp)
+    gamepad.dpad.down.valueChangedHandler = buttonHandler(.dpadDown)
 
-          gamepad.dpad.left.valueChangedHandler = buttonHandler(.dpadLeft)
-          gamepad.dpad.right.valueChangedHandler = buttonHandler(.dpadRight)
+    gamepad.dpad.left.valueChangedHandler = buttonHandler(.dpadLeft)
+    gamepad.dpad.right.valueChangedHandler = buttonHandler(.dpadRight)
     if #available(iOS 12.1, *) {
       gamepad.leftThumbstickButton?.valueChangedHandler = buttonHandler(.leftThumbstickButton)
       gamepad.rightThumbstickButton?.valueChangedHandler = buttonHandler(.rightThumbstickButton)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_gamepad
 description: An iOS gamepad library for Flutter. (Android support coming soon.)
-version: 0.1.0
+version: 0.2.0
 author: Rainway, Inc. <code@rainway.com>
 homepage: https://github.com/RainwayApp/flutter_gamepad
 


### PR DESCRIPTION
Adds Android support to the gamepad plugin.

@apecoraro @nir-ziv To test:
* Build the example app in this package on your Android device.
* Connect a Bluetooth gamepad to your device.
* Right before the first registered button press, you should see a "connected gamepad" event in the example app.
* Test all the buttons: A, B, X, Y, shoulders, stick buttons, Menu, and the directional pad. They should all produce log entries in the app. The B button should not close the app.
  * ("Select/Back" will always perform a UI action on Android, I'm afraid.)
* Test the joysticks and trigger buttons. Moving them should also produce log entries in the app.
* Test the "Call gamepads()" button in the example app: your controller's name should show up.

Basically, you should see something like this:

![image](https://user-images.githubusercontent.com/16232127/69180134-156a7480-0b0d-11ea-99ac-793876d18938.png)

