### PR TITLE
Fixed crash with null.

### DIFF
--- a/android/src/main/kotlin/com/example/flutter_gamepad/GamepadStreamHandler.kt
+++ b/android/src/main/kotlin/com/example/flutter_gamepad/GamepadStreamHandler.kt
@@ -11,7 +11,7 @@ val InputDevice.isGamepad: Boolean
     get() = sources and InputDevice.SOURCE_GAMEPAD == InputDevice.SOURCE_GAMEPAD
 
 val InputEvent.deviceIsGamepad: Boolean
-    get() = InputDevice.getDevice(deviceId).isGamepad
+    get() = InputDevice.getDevice(deviceId)?.isGamepad ?: false
 
 /**
  * A singleton object that manages the gamepad event stream. It is fed Android events and


### PR DESCRIPTION
The getDevice function can return null, so need to check
for that when checking if an input is from a gamepad.

Probably a fix for this crash that was picked up by Google Play:
```
java.lang.IllegalStateException:
  at com.example.flutter_gamepad.GamepadStreamHandlerKt.a (GamepadStreamHandlerKt.java:15)
  at com.example.flutter_gamepad.GamepadStreamHandler.a (GamepadStreamHandler.java:14)
  at com.example.flutter_gamepad.GamepadAndroidKeyProcessor.onKeyUp (GamepadAndroidKeyProcessor.java:7)
  at io.flutter.view.FlutterView.onKeyUp (FlutterView.java:13)
  at android.view.KeyEvent.dispatch (KeyEvent.java:2847)
  at android.view.View.dispatchKeyEvent (View.java:13389)
  at android.view.ViewGroup.dispatchKeyEvent (ViewGroup.java:1942)
```