### PR TITLE
Fix after upgrade, add backwards compatibility.

### DIFF
--- a/android/src/main/kotlin/com/example/flutter_gamepad/FlutterGamepadPlugin.kt
+++ b/android/src/main/kotlin/com/example/flutter_gamepad/FlutterGamepadPlugin.kt
@@ -29,7 +29,6 @@ class GamepadAndroidTouchProcessor(renderer: FlutterRenderer) : AndroidTouchProc
     }
 }
 
-
 /**
  * An extension of Flutter's AndroidKeyProcessor that delegates KeyEvents to the GamepadStreamHandler.
  * (On Android, button events from a gamepad are a kind of KeyEvent.)

--- a/android/src/main/kotlin/com/example/flutter_gamepad/FlutterGamepadPlugin.kt
+++ b/android/src/main/kotlin/com/example/flutter_gamepad/FlutterGamepadPlugin.kt
@@ -45,9 +45,12 @@ class GamepadAndroidKeyProcessor(flutterView: FlutterView, keyEventChannel: KeyE
         if (!handled) {
             return super.onKeyDown(keyEvent)
         }
-        // In the old version of this processor the onKeyDown function did not return a value, which was a problem
-        // that had to be worked around at the app level. The natural thing to do is return handled here, but
-        // doing that will break apps that have work arounds for this problem.
+        // In the old version of this processor the onKeyUp function did not return a value, which meant that
+        // the system would handle these events in addition to the plugin, which resuled in extra events being
+        // generated for button presses (for example the B button triggered a BACK event in addition to the
+        // normal B button press event). This was a problem that had to be worked around at the app level.
+        // The natural thing to do is return handled here, but doing that will break apps that have work a
+        // around for this "extra events" problem.
         return if (this.mode == Mode.backwardsCompatibility) {
             false
         } else {
@@ -60,9 +63,12 @@ class GamepadAndroidKeyProcessor(flutterView: FlutterView, keyEventChannel: KeyE
         if (!handled) {
             return super.onKeyUp(keyEvent)
         }
-        // In the old version of this processor the onKeyUp function did not return a value, which was a problem
-        // that had to be worked around at the app level. The natural thing to do is return handled here, but
-        // doing that will break apps that have work arounds for this problem.
+        // In the old version of this processor the onKeyUp function did not return a value, which meant that
+        // the system would handle these events in addition to the plugin, which resuled in extra events being
+        // generated for button presses (for example the B button triggered a BACK event in addition to the
+        // normal B button press event). This was a problem that had to be worked around at the app level.
+        // The natural thing to do is return handled here, but doing that will break apps that have work a
+        // around for this "extra events" problem.
         return if (this.mode == Mode.backwardsCompatibility) {
             false
         } else {

--- a/android/src/main/kotlin/com/example/flutter_gamepad/FlutterGamepadPlugin.kt
+++ b/android/src/main/kotlin/com/example/flutter_gamepad/FlutterGamepadPlugin.kt
@@ -35,27 +35,12 @@ class GamepadAndroidTouchProcessor(renderer: FlutterRenderer) : AndroidTouchProc
  * (On Android, button events from a gamepad are a kind of KeyEvent.)
  */
 class GamepadAndroidKeyProcessor(flutterView: FlutterView, keyEventChannel: KeyEventChannel, textInputPlugin: TextInputPlugin) : AndroidKeyProcessor(flutterView, keyEventChannel, textInputPlugin) {
-    enum class Mode {
-        normal,
-        backwardsCompatibility,
-    }
-    var mode: Mode = Mode.normal
     override fun onKeyDown(keyEvent: KeyEvent): Boolean {
         val handled = GamepadStreamHandler.processKeyEvent(keyEvent)
         if (!handled) {
             return super.onKeyDown(keyEvent)
         }
-        // In the old version of this processor the onKeyUp function did not return a value, which meant that
-        // the system would handle these events in addition to the plugin, which resuled in extra events being
-        // generated for button presses (for example the B button triggered a BACK event in addition to the
-        // normal B button press event). This was a problem that had to be worked around at the app level.
-        // The natural thing to do is return handled here, but doing that will break apps that have work a
-        // around for this "extra events" problem.
-        return if (this.mode == Mode.backwardsCompatibility) {
-            false
-        } else {
-            handled;
-        }
+        return handled;
     }
 
     override fun onKeyUp(keyEvent: KeyEvent): Boolean {
@@ -63,17 +48,7 @@ class GamepadAndroidKeyProcessor(flutterView: FlutterView, keyEventChannel: KeyE
         if (!handled) {
             return super.onKeyUp(keyEvent)
         }
-        // In the old version of this processor the onKeyUp function did not return a value, which meant that
-        // the system would handle these events in addition to the plugin, which resuled in extra events being
-        // generated for button presses (for example the B button triggered a BACK event in addition to the
-        // normal B button press event). This was a problem that had to be worked around at the app level.
-        // The natural thing to do is return handled here, but doing that will break apps that have work a
-        // around for this "extra events" problem.
-        return if (this.mode == Mode.backwardsCompatibility) {
-            false
-        } else {
-            handled;
-        }
+        return handled;
     }
 }
 
@@ -127,10 +102,6 @@ class FlutterGamepadPlugin : MethodCallHandler {
     override fun onMethodCall(call: MethodCall, result: Result) {
         if (call.method == "gamepads") {
             result.success(allGamepadInfoDictionaries())
-        } else if (call.method == "enableAndroidBackwardsCompatibilityMode") {
-            gamepadAndroidKeyProcessor?.mode = GamepadAndroidKeyProcessor.Mode.backwardsCompatibility
-        } else if (call.method == "disableAndroidBackwardsCompatibilityMode") {
-            gamepadAndroidKeyProcessor?.mode = GamepadAndroidKeyProcessor.Mode.normal
         } else if (call.method == "enableDebugMode") {
             GamepadStreamHandler.enableDebugMode(true)
         } else if (call.method == "disableDebugMode") {

--- a/android/src/main/kotlin/com/example/flutter_gamepad/FlutterGamepadPlugin.kt
+++ b/android/src/main/kotlin/com/example/flutter_gamepad/FlutterGamepadPlugin.kt
@@ -58,7 +58,6 @@ class GamepadAndroidKeyProcessor(flutterView: FlutterView, keyEventChannel: KeyE
 class FlutterGamepadPlugin : MethodCallHandler {
     companion object {
         var isTv: Boolean? = null
-        var gamepadAndroidKeyProcessor: GamepadAndroidKeyProcessor? = null
 
         @JvmStatic
         fun registerWith(registrar: Registrar) {
@@ -94,8 +93,8 @@ class FlutterGamepadPlugin : MethodCallHandler {
             val textInputPluginField = viewField("mTextInputPlugin")
             val keyEventChannel = keyEventChannelField.get(view) as KeyEventChannel
             val textInputPlugin = textInputPluginField.get(view) as TextInputPlugin
-            gamepadAndroidKeyProcessor = GamepadAndroidKeyProcessor(view, keyEventChannel, textInputPlugin)
-            keyProcessorField.set(view, gamepadAndroidKeyProcessor)
+            val keyProcessor = GamepadAndroidKeyProcessor(view, keyEventChannel, textInputPlugin)
+            keyProcessorField.set(view, keyProcessor)
         }
     }
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,42 +7,42 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.2"
+    version: "2.5.0-nullsafety.1"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0-nullsafety.1"
   characters:
     dependency: transitive
     description:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0-nullsafety.3"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.3"
+    version: "1.2.0-nullsafety.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.1.0-nullsafety.1"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.13"
+    version: "1.15.0-nullsafety.3"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -56,7 +56,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0-nullsafety.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -80,21 +80,21 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.8"
+    version: "0.12.10-nullsafety.1"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.8"
+    version: "1.3.0-nullsafety.3"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0-nullsafety.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -106,55 +106,55 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0-nullsafety.2"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.5"
+    version: "1.10.0-nullsafety.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0-nullsafety.1"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "1.1.0-nullsafety.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0-nullsafety.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.17"
+    version: "0.2.19-nullsafety.2"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0-nullsafety.3"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.8"
+    version: "2.1.0-nullsafety.3"
 sdks:
-  dart: ">=2.9.0-14.0.dev <3.0.0"
+  dart: ">=2.10.0-110 <2.11.0"

--- a/lib/flutter_gamepad.dart
+++ b/lib/flutter_gamepad.dart
@@ -62,6 +62,14 @@ class FlutterGamepad {
     return result.map((x) => GamepadInfo.decode(x)).toList();
   }
 
+  static void enableAndroidBackwardsCompatibilityMode() {
+    _methodChannel.invokeListMethod<dynamic>('enableAndroidBackwardsCompatibilityMode');
+  }
+
+  static void disableAndroidBackwardsCompatibilityMode() {
+    _methodChannel.invokeListMethod<dynamic>('disableAndroidBackwardsCompatibilityMode');
+  }
+
   static void enableDebugMode() {
     _methodChannel.invokeListMethod<dynamic>('enableDebugMode');
   }

--- a/lib/flutter_gamepad.dart
+++ b/lib/flutter_gamepad.dart
@@ -62,6 +62,11 @@ class FlutterGamepad {
     return result.map((x) => GamepadInfo.decode(x)).toList();
   }
 
+  /// Older versions of FlutterGamepad would generate "extra" events
+  /// in addition to the gamepad events (for example pressing the B-button
+  /// would also generate a BACK event). This newer version of the plugin
+  /// does not have that issue, but for apps that require this, use this
+  /// function to restore that "extra event" behavior.
   static void enableAndroidBackwardsCompatibilityMode() {
     _methodChannel.invokeListMethod<dynamic>('enableAndroidBackwardsCompatibilityMode');
   }

--- a/lib/flutter_gamepad.dart
+++ b/lib/flutter_gamepad.dart
@@ -62,19 +62,6 @@ class FlutterGamepad {
     return result.map((x) => GamepadInfo.decode(x)).toList();
   }
 
-  /// Older versions of FlutterGamepad would generate "extra" events
-  /// in addition to the gamepad events (for example pressing the B-button
-  /// would also generate a BACK event). This newer version of the plugin
-  /// does not have that issue, but for apps that require this, use this
-  /// function to restore that "extra event" behavior.
-  static void enableAndroidBackwardsCompatibilityMode() {
-    _methodChannel.invokeListMethod<dynamic>('enableAndroidBackwardsCompatibilityMode');
-  }
-
-  static void disableAndroidBackwardsCompatibilityMode() {
-    _methodChannel.invokeListMethod<dynamic>('disableAndroidBackwardsCompatibilityMode');
-  }
-
   static void enableDebugMode() {
     _methodChannel.invokeListMethod<dynamic>('enableDebugMode');
   }


### PR DESCRIPTION
After upgrading flutter this code stopped compiling, so
these changes fix that.

Also note that the upgrade also makes it so that the "extra"
events that the gamepad was generating are no longer being
generated. So this is a breaking change to the plugin.